### PR TITLE
Add setup.py to allow `pip install`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="blink",
+    version="0.1.0",
+    packages=find_packages(),
+    python_requires=">=3.0",
+    install_requires=[
+        "numpy",
+        "pandas",
+        "scipy",
+        "scikit-learn==1.0.2",
+        "seaborn",
+        "jupyter",
+        "matplotlib",
+        "rdkit-pypi",  # rdkit from PyPI
+        "matchms",
+        "networkx",
+        "pymzml",
+        "pyteomics",
+        "torch",  # Specified under pip in environment.yaml
+    ],
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    entry_points={
+        "console_scripts": [
+            # Add CLI scripts here if needed, e.g., "blink-cli = blink.cli:main"
+        ]
+    },
+)


### PR DESCRIPTION
Hey. I've been working on a blink's ['sister' project](https://github.com/PangeAI/SimMS/tree/development) recently. 

I've found it incredibly difficult to quickly install blink with pip, without cloining, cd-ing and conda installing the package. 

So I've added a simple `setup.py` for a faster install:

```sh
pip install git+https://github.com/tornikeo/blink
```

I think this will make blink a bit more comfortable for future development. Installing with pip is still very popular. 